### PR TITLE
Add record type for xml, json and csv batch results

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ string|sfdc46:SalesforceError batchRequest = csvInsertOperator->getBatchRequest(
 // Get batch result as csv.
 int noOfRetries = 5; // Number of times trying to get the results.
 int waitTime = 3000; // Time between two tries in mili-seconds.
-string|sfdc46:SalesforceError batchResult = 
+sfdc46:Result[]|sfdc46:SalesforceError batchResult = 
     csvInsertOperator->getBatchResults(batchId, noOfRetries, waitTime);
 ```
 

--- a/src/sfdc46/Module.md
+++ b/src/sfdc46/Module.md
@@ -216,7 +216,7 @@ function get results of a batch that has completed processing.
 // Retrieve the csv batch request.
 string|SalesforceError batchRequest = csvInsertOperator->getBatchRequest(batchId;
 // Get batch result as csv.
-string|SalesforceError batchResult = csvInsertOperator->getBatchResults(batchId);
+Result[]|SalesforceError batchResult = csvInsertOperator->getBatchResults(batchId);
 ```
 
 Likewise Salesforce bulk client provides following operations:

--- a/src/sfdc46/salesforceBulk/csv/csv_delete_operator.bal
+++ b/src/sfdc46/salesforceBulk/csv/csv_delete_operator.bal
@@ -123,23 +123,30 @@ public type CsvDeleteOperator client object {
     # + waitTime - time between two tries in ms
     # + return - Batch result as CSV if successful else SalesforceError occured
     public remote function getBatchResults(string batchId, int numberOfTries = 1, int waitTime = 3000) 
-        returns @tainted string | SalesforceError {
+        returns @tainted Result[]|SalesforceError {
         int counter = 0;
         while (counter < numberOfTries) {
             Batch|SalesforceError batch = self->getBatchInfo(batchId);
             
             if (batch is Batch) {
+
                 if (batch.state == COMPLETED) {
-                    return self.httpBaseClient->getCsvRecord([JOB, self.job.id, BATCH, batchId, RESULT]);
+                    string|SalesforceError result = 
+                        self.httpBaseClient->getCsvRecord([JOB, self.job.id, BATCH, batchId, RESULT]);
+                    if (result is string) {
+                        return getBatchResults(result);
+                    } else {
+                        return result;
+                    }
                 } else if (batch.state == FAILED) {
                     return getFailedBatchError(batch);
                 } else {
                     printWaitingMessage(batch);
                 }
+
             } else {
                 return batch;
             }
-
             runtime:sleep(waitTime); // Sleep 3s.
             counter = counter + 1;
         }

--- a/src/sfdc46/salesforceBulk/csv/csv_insert_operator.bal
+++ b/src/sfdc46/salesforceBulk/csv/csv_insert_operator.bal
@@ -173,19 +173,27 @@ public type CsvInsertOperator client object {
     # + waitTime - time between two tries in ms
     # + return - Batch result as CSV if successful else SalesforceError occured
     public remote function getBatchResults(string batchId, int numberOfTries = 1, int waitTime = 3000) 
-        returns @tainted string | SalesforceError {
+        returns @tainted Result[]|SalesforceError {
         int counter = 0;
         while (counter < numberOfTries) {
             Batch|SalesforceError batch = self->getBatchInfo(batchId);
             
             if (batch is Batch) {
+
                 if (batch.state == COMPLETED) {
-                    return self.httpBaseClient->getCsvRecord([JOB, self.job.id, BATCH, batchId, RESULT]);
+                    string|SalesforceError result = 
+                        self.httpBaseClient->getCsvRecord([JOB, self.job.id, BATCH, batchId, RESULT]);
+                    if (result is string) {
+                        return getBatchResults(result);
+                    } else {
+                        return result;
+                    }
                 } else if (batch.state == FAILED) {
                     return getFailedBatchError(batch);
                 } else {
                     printWaitingMessage(batch);
                 }
+                
             } else {
                 return batch;
             }

--- a/src/sfdc46/salesforceBulk/csv/csv_update_operator.bal
+++ b/src/sfdc46/salesforceBulk/csv/csv_update_operator.bal
@@ -123,19 +123,27 @@ public type CsvUpdateOperator client object {
     # + waitTime - time between two tries in ms
     # + return - Batch result as CSV if successful else SalesforceError occured
     public remote function getBatchResults(string batchId, int numberOfTries = 1, int waitTime = 3000) 
-        returns @tainted string | SalesforceError {
+        returns @tainted Result[]|SalesforceError {
         int counter = 0;
         while (counter < numberOfTries) {
             Batch|SalesforceError batch = self->getBatchInfo(batchId);
             
             if (batch is Batch) {
+
                 if (batch.state == COMPLETED) {
-                    return self.httpBaseClient->getCsvRecord([JOB, self.job.id, BATCH, batchId, RESULT]);
+                    string|SalesforceError result = 
+                        self.httpBaseClient->getCsvRecord([JOB, self.job.id, BATCH, batchId, RESULT]);
+                    if (result is string) {
+                        return getBatchResults(result);
+                    } else {
+                        return result;
+                    }
                 } else if (batch.state == FAILED) {
                     return getFailedBatchError(batch);
                 } else {
                     printWaitingMessage(batch);
                 }
+                
             } else {
                 return batch;
             }

--- a/src/sfdc46/salesforceBulk/csv/csv_upsert_operator.bal
+++ b/src/sfdc46/salesforceBulk/csv/csv_upsert_operator.bal
@@ -123,19 +123,27 @@ public type CsvUpsertOperator client object {
     # + waitTime - time between two tries in ms
     # + return - Batch result as CSV if successful else SalesforceError occured
     public remote function getBatchResults(string batchId, int numberOfTries = 1, int waitTime = 3000) 
-        returns @tainted string | SalesforceError {
+        returns @tainted Result[]|SalesforceError {
         int counter = 0;
         while (counter < numberOfTries) {
             Batch|SalesforceError batch = self->getBatchInfo(batchId);
             
             if (batch is Batch) {
+
                 if (batch.state == COMPLETED) {
-                    return self.httpBaseClient->getCsvRecord([JOB, self.job.id, BATCH, batchId, RESULT]);
+                    string|SalesforceError result = 
+                        self.httpBaseClient->getCsvRecord([JOB, self.job.id, BATCH, batchId, RESULT]);
+                    if (result is string) {
+                        return getBatchResults(result);
+                    } else {
+                        return result;
+                    }
                 } else if (batch.state == FAILED) {
                     return getFailedBatchError(batch);
                 } else {
                     printWaitingMessage(batch);
                 }
+                
             } else {
                 return batch;
             }

--- a/src/sfdc46/salesforceBulk/json/json_delete_operator.bal
+++ b/src/sfdc46/salesforceBulk/json/json_delete_operator.bal
@@ -127,20 +127,27 @@ public type JsonDeleteOperator client object {
     # + waitTime - time between two tries in ms
     # + return - Batch result as CSV if successful else SalesforceError occured
     public remote function getBatchResults(string batchId, int numberOfTries = 1, int waitTime = 3000) 
-        returns @tainted json | SalesforceError {
+        returns @tainted Result[]|SalesforceError {
         int counter = 0;
         while (counter < numberOfTries) {
             Batch|SalesforceError batch = self->getBatchInfo(batchId);
             
             if (batch is Batch) {
+                
                 if (batch.state == COMPLETED) {
-                    return self.httpBaseClient->getJsonRecord([<@untainted> JOB, self.job.id, <@untainted> BATCH, 
-                        batchId, <@untainted> RESULT]);
+                    json|SalesforceError result = 
+                        self.httpBaseClient->getJsonRecord([JOB, self.job.id, BATCH, batchId, RESULT]);
+                    if (result is json) {
+                        return getBatchResults(result);
+                    } else {
+                        return result;
+                    }
                 } else if (batch.state == FAILED) {
                     return getFailedBatchError(batch);
                 } else {
                     printWaitingMessage(batch);
                 }
+
             } else {
                 return batch;
             }

--- a/src/sfdc46/salesforceBulk/json/json_insert_operator.bal
+++ b/src/sfdc46/salesforceBulk/json/json_insert_operator.bal
@@ -175,20 +175,27 @@ public type JsonInsertOperator client object {
     # + waitTime - time between two tries in ms
     # + return - Batch result as CSV if successful else SalesforceError occured
     public remote function getBatchResults(string batchId, int numberOfTries = 1, int waitTime = 3000) 
-        returns @tainted json | SalesforceError {
+        returns @tainted Result[]|SalesforceError {
         int counter = 0;
         while (counter < numberOfTries) {
             Batch|SalesforceError batch = self->getBatchInfo(batchId);
             
             if (batch is Batch) {
+                
                 if (batch.state == COMPLETED) {
-                    return self.httpBaseClient->getJsonRecord([<@untainted> JOB, self.job.id, <@untainted> BATCH, 
-                        batchId, <@untainted> RESULT]);
+                    json|SalesforceError result = 
+                        self.httpBaseClient->getJsonRecord([JOB, self.job.id, BATCH, batchId, RESULT]);
+                    if (result is json) {
+                        return getBatchResults(result);
+                    } else {
+                        return result;
+                    }
                 } else if (batch.state == FAILED) {
                     return getFailedBatchError(batch);
                 } else {
                     printWaitingMessage(batch);
                 }
+
             } else {
                 return batch;
             }

--- a/src/sfdc46/salesforceBulk/json/json_update_operator.bal
+++ b/src/sfdc46/salesforceBulk/json/json_update_operator.bal
@@ -127,20 +127,27 @@ public type JsonUpdateOperator client object {
     # + waitTime - time between two tries in ms
     # + return - Batch result as CSV if successful else SalesforceError occured
     public remote function getBatchResults(string batchId, int numberOfTries = 1, int waitTime = 3000) 
-        returns @tainted json | SalesforceError {
+        returns @tainted Result[]|SalesforceError {
         int counter = 0;
         while (counter < numberOfTries) {
             Batch|SalesforceError batch = self->getBatchInfo(batchId);
             
             if (batch is Batch) {
+
                 if (batch.state == COMPLETED) {
-                    return self.httpBaseClient->getJsonRecord([<@untainted> JOB, self.job.id, <@untainted> BATCH, 
-                        batchId, <@untainted> RESULT]);
+                    json|SalesforceError result = 
+                        self.httpBaseClient->getJsonRecord([JOB, self.job.id, BATCH, batchId, RESULT]);
+                    if (result is json) {
+                        return getBatchResults(result);
+                    } else {
+                        return result;
+                    }
                 } else if (batch.state == FAILED) {
                     return getFailedBatchError(batch);
                 } else {
                     printWaitingMessage(batch);
                 }
+
             } else {
                 return batch;
             }

--- a/src/sfdc46/salesforceBulk/salesforceTypes/result.bal
+++ b/src/sfdc46/salesforceBulk/salesforceTypes/result.bal
@@ -1,0 +1,193 @@
+//
+// Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+public type Result record {
+    string id?;
+    boolean success;
+    boolean created;
+    string errors?;
+};
+
+function getBatchResults(xml|json|string batchResult) returns Result[]|SalesforceError {
+    if (batchResult is xml) {
+        return createBatchResultRecordFromXml(batchResult);
+    } else if (batchResult is string) {
+        return createBatchResultRecordFromCsv(batchResult);
+    } else {
+        return createBatchResultRecordFromJson(batchResult);
+    }
+}
+
+function createBatchResultRecordFromXml(xml payload) returns Result[]| SalesforceError {
+    Result[] batchResArr = [];
+
+    foreach var result in payload.*.elements() {
+        if (result is xml) {
+            Result|error batchRes = trap {
+                success: getBooleanValue(result[getElementNameWithNamespace("success")].getTextValue()),
+                created: getBooleanValue(result[getElementNameWithNamespace("created")].getTextValue())
+            };
+
+            if (batchRes is Result) {
+                // Check whether ID exists
+                if (result.id.getTextValue().length() > 0) {
+                    batchRes.id = result.id.getTextValue();
+                }
+                // Check whether errors exists
+                xml|error errors = result.errors;
+                if (errors is xml) {
+
+                    if (errors.toString().length() > 0) {
+                        log:printError("Failed batch result, errors=" + errors.toString(), err = ());
+                        batchRes.errors = "[" + errors.statusCode.getTextValue() + "] " + errors.message.getTextValue();
+                    }
+                }
+                // Add to batch results array.
+                batchResArr[batchResArr.length()] = batchRes;
+            } else {
+                log:printError("Error occurred while creating BatchResult record.", err = batchRes);
+                return getSalesforceError("Error occurred while creating BatchResult record.", 
+                    http:STATUS_INTERNAL_SERVER_ERROR.toString());
+            }
+        } else {
+            // log:printInfo("Error occurred while getting batch results.",  err = result);
+            log:printError("Error occurred while getting batch results, result=" + result.toString(), ());
+            return getSalesforceError("Error occurred while getting batch results.", 
+                http:STATUS_INTERNAL_SERVER_ERROR.toString());
+        }
+    }
+    return batchResArr;
+}
+
+function createBatchResultRecordFromJson(json payload) returns Result[]|SalesforceError {
+    Result[] batchResArr = [];
+    json[] payloadArr = <json[]> payload;
+
+    foreach json ele in payloadArr {
+        Result|error batchRes = trap {
+            success: getBooleanValue(ele.success.toString()),
+            created: getBooleanValue(ele.created.toString())
+        };
+
+        if (batchRes is Result) {
+            // Check whether ID exists
+            if (ele.id.toString().length() > 0 && ele.id.toString() != "null") {
+                batchRes.id = ele.id.toString();
+            }
+            // Check whether errors exists
+            json|error errors = ele.errors;
+
+            if (errors is json) {
+
+                if (errors.toString() != "[]") {
+                    log:printError("Failed batch result, errors=" + errors.toString(), err = ());
+                    json[] errorsArr = <json[]> errors;
+                    string errMsg = "";
+                    int counter = 1;
+                    foreach json err in errorsArr {
+                        errMsg = errMsg + "[" + err.statusCode.toString() + "] " + err.message.toString();
+                        if (errorsArr.length() != counter) {
+                            errMsg = errMsg + ", ";
+                        }
+                        counter = counter + 1;
+                    }
+                    batchRes.errors = errMsg;
+                }
+                
+            } else {
+                log:printError("Error occurred while accessing errors from batch result, errors=" + errors.toString(), 
+                    err = ());
+                return getSalesforceError("Error occurred while accessing errors from batch result.", 
+                    http:STATUS_INTERNAL_SERVER_ERROR.toString());
+            }
+            batchResArr[batchResArr.length()] = batchRes;
+        } else {
+            log:printError("Error occurred while creating BatchResult record.", err = batchRes);
+            return getSalesforceError("Error occurred while creating BatchResult record.", 
+                http:STATUS_INTERNAL_SERVER_ERROR.toString());
+        }
+        
+    }
+    return batchResArr;
+}
+
+function createBatchResultRecordFromCsv(string payload) returns Result[]|SalesforceError {
+    Result[] batchResArr = [];
+
+    handle payloadArr = split(java:fromString(payload), java:fromString("\n"));
+    int arrLength = java:getArrayLength(payloadArr);
+
+    int counter = 1;
+    while (counter < arrLength) {
+        string? line = java:toString(java:getArrayElement(payloadArr, counter));
+
+        if (line is string) {
+            handle lineArr = split(java:fromString(line), java:fromString(","));
+
+            string? idStr = java:toString(java:getArrayElement(lineArr, 0));
+            string? successStr = java:toString(java:getArrayElement(lineArr, 1));
+            string? createdStr = java:toString(java:getArrayElement(lineArr, 2));
+            string? errorStr = java:toString(java:getArrayElement(lineArr, 3));
+
+            // Remove quotes of "true" or "false".
+            if (successStr is string && createdStr is string) {
+                successStr = java:toString(replace(java:fromString(successStr), java:fromString("\""), 
+                    java:fromString("")));
+                createdStr = java:toString(replace(java:fromString(createdStr), java:fromString("\""), 
+                    java:fromString("")));
+            }
+
+            if (successStr is string && successStr.length() > 0 && createdStr is string && createdStr.length() > 0) {
+
+                Result|error batchRes = trap {
+                    success: getBooleanValue(successStr),
+                    created: getBooleanValue(createdStr)
+                };
+
+                if (batchRes is Result) {
+                    if (idStr is string && idStr.length() > 0) {
+                        batchRes.id = idStr;
+                    }
+                    if (errorStr is string && errorStr.length() > 0) {
+                        batchRes.errors = errorStr;
+                    }
+                    // Add batch result to array.
+                    batchResArr[batchResArr.length()] = batchRes;
+                } else {
+                    log:printError("Error occurred while creating BatchResult record, batchRes=" 
+                        + batchRes.toString());
+                    return getSalesforceError("Error occurred while creating BatchResult record.", 
+                        http:STATUS_INTERNAL_SERVER_ERROR.toString());
+                }
+                
+            } else {
+                log:printError("Error occurred while accessing success & created fields from batch result, success=" 
+                    + successStr.toString() + " created=" + createdStr.toString());
+                return getSalesforceError("Error occurred while accessing success & created fields from batch result.", 
+                    http:STATUS_INTERNAL_SERVER_ERROR.toString());
+            }
+        } else {
+            log:printError("Error occrred while retrieveing batch result line from batch results csv, line=" 
+                + line.toString());
+            return getSalesforceError("Error occurred while retrieveing batch result line from batch results csv.", 
+                    http:STATUS_INTERNAL_SERVER_ERROR.toString());
+        }
+        counter = counter + 1;
+    }
+    return batchResArr;
+}

--- a/src/sfdc46/salesforceBulk/xml/xml_delete_operator.bal
+++ b/src/sfdc46/salesforceBulk/xml/xml_delete_operator.bal
@@ -123,19 +123,27 @@ public type XmlDeleteOperator client object {
     # + waitTime - time between two tries in ms
     # + return - Batch result as CSV if successful else SalesforceError occured
     public remote function getBatchResults(string batchId, int numberOfTries = 1, int waitTime = 3000) 
-        returns @tainted xml | SalesforceError {
+        returns @tainted Result[]|SalesforceError {
         int counter = 0;
         while (counter < numberOfTries) {
             Batch|SalesforceError batch = self->getBatchInfo(batchId);
             
             if (batch is Batch) {
+
                 if (batch.state == COMPLETED) {
-                    return self.httpBaseClient->getXmlRecord([JOB, self.job.id, BATCH, batchId, RESULT]);
+                    xml|SalesforceError result = 
+                        self.httpBaseClient->getXmlRecord([JOB, self.job.id, BATCH, batchId, RESULT]);
+                    if (result is xml) {
+                        return getBatchResults(result);
+                    } else {
+                        return result;
+                    }
                 } else if (batch.state == FAILED) {
                     return getFailedBatchError(batch);
                 } else {
                     printWaitingMessage(batch);
                 }
+
             } else {
                 return batch;
             }

--- a/src/sfdc46/salesforceBulk/xml/xml_insert_operator.bal
+++ b/src/sfdc46/salesforceBulk/xml/xml_insert_operator.bal
@@ -171,19 +171,27 @@ public type XmlInsertOperator client object {
     # + waitTime - time between two tries in ms
     # + return - Batch result as CSV if successful else SalesforceError occured
     public remote function getBatchResults(string batchId, int numberOfTries = 1, int waitTime = 3000) 
-        returns @tainted xml | SalesforceError {
+        returns @tainted Result[]|SalesforceError {
         int counter = 0;
         while (counter < numberOfTries) {
             Batch|SalesforceError batch = self->getBatchInfo(batchId);
             
             if (batch is Batch) {
+                
                 if (batch.state == COMPLETED) {
-                    return self.httpBaseClient->getXmlRecord([JOB, self.job.id, BATCH, batchId, RESULT]);
+                    xml|SalesforceError result = 
+                        self.httpBaseClient->getXmlRecord([JOB, self.job.id, BATCH, batchId, RESULT]);
+                    if (result is xml) {
+                        return getBatchResults(result);
+                    } else {
+                        return result;
+                    }
                 } else if (batch.state == FAILED) {
                     return getFailedBatchError(batch);
                 } else {
                     printWaitingMessage(batch);
                 }
+
             } else {
                 return batch;
             }

--- a/src/sfdc46/salesforceBulk/xml/xml_upsert_operator.bal
+++ b/src/sfdc46/salesforceBulk/xml/xml_upsert_operator.bal
@@ -125,19 +125,27 @@ public type XmlUpsertOperator client object {
     # + waitTime - time between two tries in ms
     # + return - Batch result as CSV if successful else SalesforceError occured
     public remote function getBatchResults(string batchId, int numberOfTries = 1, int waitTime = 3000) 
-        returns @tainted xml | SalesforceError {
+        returns @tainted Result[]|SalesforceError {
         int counter = 0;
         while (counter < numberOfTries) {
             Batch|SalesforceError batch = self->getBatchInfo(batchId);
             
             if (batch is Batch) {
+                
                 if (batch.state == COMPLETED) {
-                    return self.httpBaseClient->getXmlRecord([JOB, self.job.id, BATCH, batchId, RESULT]);
+                    xml|SalesforceError result = 
+                        self.httpBaseClient->getXmlRecord([JOB, self.job.id, BATCH, batchId, RESULT]);
+                    if (result is xml) {
+                        return getBatchResults(result);
+                    } else {
+                        return result;
+                    }
                 } else if (batch.state == FAILED) {
                     return getFailedBatchError(batch);
                 } else {
                     printWaitingMessage(batch);
                 }
+
             } else {
                 return batch;
             }

--- a/src/sfdc46/tests/bulk/bulk_test_utils.bal
+++ b/src/sfdc46/tests/bulk/bulk_test_utils.bal
@@ -14,77 +14,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-function checkRequestResponse(json[] arr) returns boolean {
-    foreach json|error ele in arr {
-        json|error res = ele.success;
-        if (res is json) {
-            if (res.toString() == "false") {
-                return false;
-            }
-        } else {
-            return false;
-        }
-    }
-    return true;
-}
-
-function checkCsvBatchResult(string result) returns boolean {
-    handle arr = split(java:fromString(result), java:fromString("\n"));
-    int arrLength = java:getArrayLength(arr);
-
-    int counter = 1;
-    while (counter < arrLength) {
-        string? line = java:toString(java:getArrayElement(arr, counter));
-
-        if (line is string) {
-            handle lineArr = split(java:fromString(line), java:fromString(","));
-            string? successStr = java:toString(java:getArrayElement(lineArr, 1));
-
-            if (successStr is string) {
-                // Remove quotes of the success string.
-                string? remSuccessStr = java:toString(
-                    replace(java:fromString(successStr), java:fromString("\""), java:fromString(""))
-                );
-
-                if (remSuccessStr is string) {
-                    if (!getBooleanValue(remSuccessStr)) {
-                        // Record is un-successful.
-                        log:printError("Failed result, line=" + line + " result=" + result, err = ());
-                        return false;
-                    } 
-                } else {
-                    log:printError("remSuccessStr is empty, remSuccessStr=" + remSuccessStr.toString() + " successStr=" 
-                    + successStr.toString() + " line=" + line.toString() + " result=" + result.toString(), err = ());
-                    return false;
-                }
-            } else {
-                log:printError("successStr is empty, successStr=" + successStr.toString() + " line=" + line.toString() 
-                    + " result=" + result.toString(), err = ());
-                return false;
-            }
-            
-        } else {
-            log:printError("Line is empty, line=" + line.toString() + " result=" + result.toString(), err = ());
-            return false;
-        }
-        counter = counter + 1;
-    }
-    return true;
-}
-
-function validateXmlBatchResult(xml batchRes) returns boolean {
-    foreach var result in batchRes.*.elements() {
-        if (result is xml) {
-            if (!getBooleanValue(result[getElementNameWithNamespace("success")].getTextValue())) {
-                // Record is un-successful.
-                log:printError("Failed result, success=" 
-                    + result[getElementNameWithNamespace("success")].getTextValue().toString() + " result=" 
-                    + result.toString(), err = ());
-                return false;
-            }           
-        } else {
-            log:printError("result is not xml, result=" + result.toString() + " batchRes=" + batchRes.toString(),
-                err = ());
+function checkBatchResults(Result[] results) returns boolean {
+    foreach Result res in results {
+        if (!res.success) {
+            log:printError("Failed result, res=" + res.toString(), err = ());
             return false;
         }
     }

--- a/src/sfdc46/tests/bulk/csv/csv_delete_op_test.bal
+++ b/src/sfdc46/tests/bulk/csv/csv_delete_op_test.bal
@@ -78,10 +78,10 @@ function testCsvDeleteOperator() {
         }
 
         // Get batch results.
-        string|SalesforceError batchResults = csvDeleteOperator->getBatchResults(batchId, noOfRetries);
-        if (batchResults is string) {
+        Result[]|SalesforceError batchResults = csvDeleteOperator->getBatchResults(batchId, noOfRetries);
+        if (batchResults is Result[]) {
             test:assertTrue(batchResults.length() > 0, msg = "Getting batch results failed.");
-            test:assertTrue(checkCsvBatchResult(batchResults), "Delete result was not successful.");
+            test:assertTrue(checkBatchResults(batchResults), "Delete result was not successful.");
         } else {
             test:assertFail(msg = batchResults.message);
         }

--- a/src/sfdc46/tests/bulk/csv/csv_insert_op_test.bal
+++ b/src/sfdc46/tests/bulk/csv/csv_insert_op_test.bal
@@ -92,10 +92,10 @@ Created_from_Ballerina_Sf_Bulk_API,Peter,Shane,Professor Grade 04,0332211777,pet
         }
 
         // Get the results of the batch
-        string|SalesforceError batchResult = csvInsertOperator->getBatchResults(batchIdUsingCsv, noOfRetries);
+        Result[]|SalesforceError batchResult = csvInsertOperator->getBatchResults(batchIdUsingCsv, noOfRetries);
 
-        if (batchResult is string) {
-            test:assertTrue(checkCsvBatchResult(batchResult), "Insert result was not successful.");
+        if (batchResult is Result[]) {
+            test:assertTrue(checkBatchResults(batchResult), "Insert result was not successful.");
         } else {
             test:assertFail(msg = batchResult.message);
         }

--- a/src/sfdc46/tests/bulk/csv/csv_update_op_test.bal
+++ b/src/sfdc46/tests/bulk/csv/csv_update_op_test.bal
@@ -83,10 +83,10 @@ function testCsvUpdateOperator() {
         }
 
         // Get the results of the batch
-        string|SalesforceError batchResult = csvUpdateOperator->getBatchResults(batchId, noOfRetries);
-        if (batchResult is string) {
+        Result[]|SalesforceError batchResult = csvUpdateOperator->getBatchResults(batchId, noOfRetries);
+        if (batchResult is Result[]) {
             test:assertTrue(batchResult.length() > 0, msg = "Getting batch results failed.");
-            test:assertTrue(checkCsvBatchResult(batchResult), "Insert result was not successful.");
+            test:assertTrue(checkBatchResults(batchResult), "Insert result was not successful.");
         } else {
             test:assertFail(msg = batchResult.message);
         }

--- a/src/sfdc46/tests/bulk/csv/csv_upsert_op_test.bal
+++ b/src/sfdc46/tests/bulk/csv/csv_upsert_op_test.bal
@@ -81,10 +81,10 @@ Created_from_Ballerina_Sf_Bulk_API,Pedro,Guterez,Professor Grade 04,0445567100,p
         }
 
         // Get the results of the batch
-        string|SalesforceError batchResult = csvUpsertOperator->getBatchResults(batchId, noOfRetries);
-        if (batchResult is string) {
+        Result[]|SalesforceError batchResult = csvUpsertOperator->getBatchResults(batchId, noOfRetries);
+        if (batchResult is Result[]) {
             test:assertTrue(batchResult.length() > 0, msg = "Getting batch results failed.");
-            test:assertTrue(checkCsvBatchResult(batchResult), "Insert result was not successful.");
+            test:assertTrue(checkBatchResults(batchResult), "Insert result was not successful.");
         } else {
             test:assertFail(msg = batchResult.message);
         }

--- a/src/sfdc46/tests/bulk/json/json_delete_op_test.bal
+++ b/src/sfdc46/tests/bulk/json/json_delete_op_test.bal
@@ -79,11 +79,11 @@ function testJsonDeleteOperator() {
         }
 
         // Get batch results.
-        json|SalesforceError batchResults = jsonDeleteOperator->getBatchResults(batchId, noOfRetries);
+        Result[]|SalesforceError batchResults = jsonDeleteOperator->getBatchResults(batchId, noOfRetries);
 
-        if (batchResults is json) {
-            json[] batchResultsArr = <json[]> batchResults;
-            test:assertTrue(batchResultsArr.length() > 0, msg = "Getting batch results failed.");
+        if (batchResults is Result[]) {
+            test:assertTrue(batchResults.length() > 0, msg = "Getting batch results failed.");
+            test:assertTrue(checkBatchResults(batchResults), msg = "Delete result was not successful.");
         } else {
             test:assertFail(msg = batchResults.message);
         }

--- a/src/sfdc46/tests/bulk/json/json_insert_op_test.bal
+++ b/src/sfdc46/tests/bulk/json/json_insert_op_test.bal
@@ -114,15 +114,11 @@ function testJsonInsertOperator() {
         }
 
         // Get the results of the batch
-        json|SalesforceError batchResult = jsonInsertOperator->getBatchResults(batchIdUsingJson, noOfRetries);
+        Result[]|SalesforceError batchResult = jsonInsertOperator->getBatchResults(batchIdUsingJson, noOfRetries);
 
-        if (batchResult is json) {
-            json[]|error batchResultArr = <json[]> batchResult;
-            if (batchResultArr is json[]) {
-                test:assertTrue(batchResultArr.length() == 2, msg = "Retrieving batch result failed.");                
-            } else {
-                test:assertFail(msg = batchResultArr.toString());
-            }
+        if (batchResult is Result[]) {
+            test:assertTrue(batchResult.length() > 0, msg = "Retrieving batch result failed.");
+            test:assertTrue(checkBatchResults(batchResult), msg = "Insert result was not successful.");                
         } else {
             test:assertFail(msg = batchResult.message);
         }

--- a/src/sfdc46/tests/bulk/json/json_update_op_test.bal
+++ b/src/sfdc46/tests/bulk/json/json_update_op_test.bal
@@ -107,16 +107,11 @@ function testJsonUpdateOperator() {
         }
 
         // Get the results of the batch
-        json|SalesforceError batchResult = jsonUpdateOperator->getBatchResults(batchIdUsingJson, noOfRetries);
+        Result[]|SalesforceError batchResult = jsonUpdateOperator->getBatchResults(batchIdUsingJson, noOfRetries);
 
-        if (batchResult is json) {
-            json[]|error batchResultArr = <json[]> batchResult;
-            if (batchResultArr is json[]) {
-                test:assertTrue(batchResultArr.length() == 2, msg = "Retrieving batch result failed.");
-                test:assertTrue(checkRequestResponse(batchResultArr), msg = "Update result was not successful.");
-            } else {
-                test:assertFail(msg = batchResultArr.toString());
-            }
+        if (batchResult is Result[]) {
+            test:assertTrue(batchResult.length() > 0, msg = "Retrieving batch result failed.");
+            test:assertTrue(checkBatchResults(batchResult), msg = "Update result was not successful.");
         } else {
             test:assertFail(msg = batchResult.message);
         }

--- a/src/sfdc46/tests/bulk/json/json_upsert_op_test.bal
+++ b/src/sfdc46/tests/bulk/json/json_upsert_op_test.bal
@@ -102,16 +102,11 @@ function testJsonUpsertOperator() {
         }
 
         // Get the results of the batch
-        json|SalesforceError batchResult = jsonUpsertOperator->getBatchResults(batchIdUsingJson, noOfRetries);
+        Result[]|SalesforceError batchResult = jsonUpsertOperator->getBatchResults(batchIdUsingJson, noOfRetries);
 
-        if (batchResult is json) {
-            json[]|error batchResultArr = <json[]> batchResult;
-            if (batchResultArr is json[]) {
-                test:assertTrue(batchResultArr.length() == 2, msg = "Retrieving batch result failed.");
-                test:assertTrue(checkRequestResponse(batchResultArr), msg = "Upsert result was not successful.");
-            } else {
-                test:assertFail(msg = batchResultArr.toString());
-            }
+        if (batchResult is Result[]) {
+            test:assertTrue(batchResult.length() > 0, msg = "Retrieving batch result failed.");
+            test:assertTrue(checkBatchResults(batchResult), msg = "Upsert result was not successful.");
         } else {
             test:assertFail(msg = batchResult.message);
         }

--- a/src/sfdc46/tests/bulk/xml/xml_delete_op_test.bal
+++ b/src/sfdc46/tests/bulk/xml/xml_delete_op_test.bal
@@ -88,10 +88,10 @@ function testXmlDeleteOperator() {
         }
 
         // Get batch results.
-        xml|SalesforceError batchResults = xmlDeleteOperator->getBatchResults(batchId, noOfRetries);
+        Result[]|SalesforceError batchResults = xmlDeleteOperator->getBatchResults(batchId, noOfRetries);
 
-        if (batchResults is xml) {
-            test:assertTrue(validateXmlBatchResult(batchResults), msg = "Invalid batch result.");  
+        if (batchResults is Result[]) {
+            test:assertTrue(checkBatchResults(batchResults), msg = "Invalid batch result.");  
         } else {
             test:assertFail(msg = batchResults.message);
         }

--- a/src/sfdc46/tests/bulk/xml/xml_insert_op_test.bal
+++ b/src/sfdc46/tests/bulk/xml/xml_insert_op_test.bal
@@ -118,10 +118,10 @@ function testXmlInsertOperator() {
         }
 
         // Get the results of the batch
-        xml|SalesforceError batchResult = xmlInsertOperator->getBatchResults(batchIdUsingXml, noOfRetries);
+        Result[]|SalesforceError batchResult = xmlInsertOperator->getBatchResults(batchIdUsingXml, noOfRetries);
 
-        if (batchResult is xml) {
-            test:assertTrue(validateXmlBatchResult(batchResult), msg = "Invalid batch result.");                
+        if (batchResult is Result[]) {
+            test:assertTrue(checkBatchResults(batchResult), msg = "Invalid batch result.");                
         } else {
             test:assertFail(msg = batchResult.message);
         }

--- a/src/sfdc46/tests/bulk/xml/xml_update_op_test.bal
+++ b/src/sfdc46/tests/bulk/xml/xml_update_op_test.bal
@@ -111,10 +111,10 @@ function testXmlUpdateOperator() {
         }
 
         // Get the results of the batch
-        xml|SalesforceError batchResult = xmlUpdateOperator->getBatchResults(batchIdUsingXml, noOfRetries);
+        Result[]|SalesforceError batchResult = xmlUpdateOperator->getBatchResults(batchIdUsingXml, noOfRetries);
 
-        if (batchResult is xml) {
-            test:assertTrue(validateXmlBatchResult(batchResult), msg = "Invalid batch result.");                
+        if (batchResult is Result[]) {
+            test:assertTrue(checkBatchResults(batchResult), msg = "Invalid batch result.");                
         } else {
             test:assertFail(msg = batchResult.message);
         }

--- a/src/sfdc46/tests/bulk/xml/xml_upsert_op_test.bal
+++ b/src/sfdc46/tests/bulk/xml/xml_upsert_op_test.bal
@@ -107,10 +107,10 @@ function testXmlUpsertOperator() {
         }
 
         // Get the results of the batch
-        xml|SalesforceError batchResult = xmlUpsertOperator->getBatchResults(batchIdUsingXml, noOfRetries);
+        Result[]|SalesforceError batchResult = xmlUpsertOperator->getBatchResults(batchIdUsingXml, noOfRetries);
 
-        if (batchResult is xml) {
-            test:assertTrue(validateXmlBatchResult(batchResult), msg = "Invalid batch result.");                
+        if (batchResult is Result[]) {
+            test:assertTrue(checkBatchResults(batchResult), msg = "Invalid batch result.");                
         } else {
             test:assertFail(msg = batchResult.message);
         }


### PR DESCRIPTION
## Purpose
> Added record type `Result` to represent batch results. Each `Result` record will represent the result of a one data point. 
`getBatchResults` method will return `Result[]`, to represent all data points of a particular batch without returning XML, JSON or string results as early implementation.